### PR TITLE
Add support for creating / deleting warrants with a policy

### DIFF
--- a/lib/warrant/models/pricing_tier.rb
+++ b/lib/warrant/models/pricing_tier.rb
@@ -273,7 +273,6 @@ module Warrant
         #
         # @param feature_id [String] The feature_id of the feature to check whether the pricing tier has access to.
         # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @option options [Boolean] :consistent_read Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @option options [Boolean] :debug Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @return [Boolean] whether or not the pricing tier has the given feature
@@ -290,7 +289,6 @@ module Warrant
                     object_id: pricing_tier_id
                 },
                 context: opts[:context],
-                consistent_read: opts[:consistent_read],
                 debug: opts[:debug]
             )
         end

--- a/lib/warrant/models/tenant.rb
+++ b/lib/warrant/models/tenant.rb
@@ -356,7 +356,6 @@ module Warrant
         #
         # @param feature_id [String] The feature_id of the feature to check whether the tenant has access to.
         # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @option options [Boolean] :consistent_read Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @option options [Boolean] :debug Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @ return [Boolean] whether or not the tenant has the given feature
@@ -373,7 +372,6 @@ module Warrant
                     object_id: tenant_id
                 },
                 context: opts[:context],
-                consistent_read: opts[:consistent_read],
                 debug: opts[:debug]
             )
         end

--- a/lib/warrant/models/user.rb
+++ b/lib/warrant/models/user.rb
@@ -307,7 +307,6 @@ module Warrant
         #
         # @param permission_id [String] The permission_id of the permission you want to check whether or not it exists on the user.
         # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @option options [Boolean] :consistent_read Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @option options [Boolean] :debug Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @return [Boolean] whether or not the user has the given permission
@@ -325,7 +324,6 @@ module Warrant
                 permission_id: permission_id,
                 user_id: user_id,
                 context: opts[:context],
-                consistent_read: opts[:consistent_read],
                 debug: opts[:debug]
             )
         end
@@ -497,7 +495,6 @@ module Warrant
         #
         # @param feature_id [String] The feature_id of the feature to check whether the user has access to.
         # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @option options [Boolean] :consistent_read Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @option options [Boolean] :debug Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @ return [Boolean] whether or not the user has the given feature
@@ -514,7 +511,6 @@ module Warrant
                     object_id: user_id
                 },
                 context: opts[:context],
-                consistent_read: opts[:consistent_read],
                 debug: opts[:debug]
             )
         end

--- a/lib/warrant/models/warrant.rb
+++ b/lib/warrant/models/warrant.rb
@@ -2,15 +2,15 @@
 
 module Warrant
     class Warrant
-        attr_reader :id, :object_type, :object_id, :relation, :subject, :context, :is_implicit
+        attr_reader :id, :object_type, :object_id, :relation, :subject, :policy, :is_implicit
 
         # @!visibility private
-        def initialize(object_type, object_id, relation, subject, context = nil, is_implicit = nil)
+        def initialize(object_type, object_id, relation, subject, policy = nil, is_implicit = nil)
             @object_type = object_type
             @object_id = object_id
             @relation = relation
             @subject = subject
-            @context = context
+            @policy = policy
             @is_implicit = is_implicit
         end
 
@@ -19,7 +19,7 @@ module Warrant
         # @param object [WarrantObject | Hash] Object to check in the access check. Object must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`). The object type must be one of your system's existing object type.
         # @param relation [String] The relation to check for this object to subject association. The relation must be valid as per the object type definition.
         # @param subject [WarrantObject | Hash] Subject to check in the access check. Subject must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`).
-        # @param context [Hash] - Object containing key-value pairs that specifies the context the warrant should be created for. (optional)
+        # @param policy [String] - A boolean expression that must evaluate to `true` for this warrant to apply. The expression can reference variables that are provided in the `context` attribute of access check requests. (optional)
         #
         # @return [Warrant] created warrant
         #
@@ -30,7 +30,7 @@ module Warrant
         # @raise [Warrant::NotFoundError]
         # @raise [Warrant::UnauthorizedError]
         # @raise [Warrant::WarrantError]
-        def self.create(object, relation, subject, context = nil)
+        def self.create(object, relation, subject, policy = nil)
             params = {
                 object_type: object.respond_to?(:warrant_object_type) ? object.warrant_object_type.to_s : object[:object_type],
                 object_id: object.respond_to?(:warrant_object_id) ? object.warrant_object_id.to_s : object[:object_id],
@@ -39,7 +39,7 @@ module Warrant
                     object_type: subject.respond_to?(:warrant_object_type) ? subject.warrant_object_type.to_s : subject[:object_type],
                     object_id: subject.respond_to?(:warrant_object_id) ? subject.warrant_object_id.to_s : subject[:object_id]
                 },
-                context: context
+                policy: policy
             }
             res = APIOperations.post(URI.parse("#{::Warrant.config.api_base}/v1/warrants"), Util.normalize_params(params))
             res_json = JSON.parse(res.body)
@@ -47,7 +47,7 @@ module Warrant
             case res
             when Net::HTTPSuccess
                 subject = Subject.new(res_json['subject']['objectType'], res_json['subject']['objectId'], res_json['subject']['relation'])
-                Warrant.new(res_json['objectType'], res_json['objectId'], res_json['relation'], subject, res_json['context'])
+                Warrant.new(res_json['objectType'], res_json['objectId'], res_json['relation'], subject, res_json['policy'])
             else
                 APIOperations.raise_error(res)
             end
@@ -58,7 +58,7 @@ module Warrant
         # @param object [WarrantObject | Hash] Object to check in the access check. Object must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`). The object type must be one of your system's existing object type.
         # @param relation [String] The relation to check for this object to subject association. The relation must be valid as per the object type definition.
         # @param subject [WarrantObject | Hash] Subject to check in the access check. Subject must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`).
-        # @param context [Hash] - Object containing key-value pairs that specifies the context the warrant should be deleted in. (optional)
+        # @param policy [String] - A boolean expression that must evaluate to `true` for this warrant to apply. The expression can reference variables that are provided in the `context` attribute of access check requests. (optional)
         #
         # @return [nil] if delete was successful
         #
@@ -67,7 +67,7 @@ module Warrant
         # @raise [Warrant::NotFoundError]
         # @raise [Warrant::UnauthorizedError]
         # @raise [Warrant::WarrantError]
-        def self.delete(object, relation, subject, context = nil)
+        def self.delete(object, relation, subject, policy = nil)
             params = {
                 object_type: object.respond_to?(:warrant_object_type) ? object.warrant_object_type.to_s : object[:object_type],
                 object_id: object.respond_to?(:warrant_object_id) ? object.warrant_object_id.to_s : object[:object_id],
@@ -76,7 +76,7 @@ module Warrant
                     object_type: subject.respond_to?(:warrant_object_type) ? subject.warrant_object_type.to_s : subject[:object_type],
                     object_id: subject.respond_to?(:warrant_object_id) ? subject.warrant_object_id.to_s : subject[:object_id]
                 },
-                context: context
+                policy: policy
             }
             res = APIOperations.delete(URI.parse("#{::Warrant.config.api_base}/v1/warrants"), Util.normalize_params(params))
 
@@ -166,7 +166,7 @@ module Warrant
         #       * object_type (String) - The type of object. Must be one of your system's existing object types.
         #       * object_id (String) - The id of the specific object.
         #       * relation (String) - The relation for this object to subject association. The relation must be valid as per the object type definition. (optional)
-        # @param context [Hash] - Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
+        #   * context [Hash] - Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
         # @param consistent_read [Boolean] Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @param debug [Boolean] Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
@@ -201,7 +201,7 @@ module Warrant
         # @param object [WarrantObject] Object to check in the access check. Object must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`). The object type must be one of your system's existing object type.
         # @param relation [String] The relation to check for this object to subject association. The relation must be valid as per the object type definition.
         # @param subject [WarrantObject] Subject to check in the access check. Subject must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`).
-        # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional) (optional)
+        # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
         # @option options [Boolean] :consistent_read Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @option options [Boolean] :debug Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #

--- a/lib/warrant/models/warrant.rb
+++ b/lib/warrant/models/warrant.rb
@@ -167,7 +167,6 @@ module Warrant
         #       * object_id (String) - The id of the specific object.
         #       * relation (String) - The relation for this object to subject association. The relation must be valid as per the object type definition. (optional)
         #   * context [Hash] - Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @param consistent_read [Boolean] Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @param debug [Boolean] Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @return [Boolean] whether or not the given access check is authorized
@@ -202,7 +201,6 @@ module Warrant
         # @param relation [String] The relation to check for this object to subject association. The relation must be valid as per the object type definition.
         # @param subject [WarrantObject] Subject to check in the access check. Subject must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`).
         # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @option options [Boolean] :consistent_read Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @option options [Boolean] :debug Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @return [Boolean] whether or not the given access check is authorized
@@ -239,7 +237,6 @@ module Warrant
                         subject: subject,
                         context: options[:context]
                     }],
-                    consistent_read: options[:consistent_read],
                     debug: options[:debug]
                 )
             end
@@ -252,7 +249,6 @@ module Warrant
                     subject: subject,
                     context: options[:context]
                 }],
-                consistent_read: options[:consistent_read],
                 debug: options[:debug]
             )
         end
@@ -265,7 +261,6 @@ module Warrant
         #   * relation (String) - The relation to check for this object to subject association. The relation must be valid as per the object type definition.
         #   * subject (WarrantObject) Subject to check in the access check. Subject must include WarrantObject module and implements its methods (`warrant_object_type` and `warrant_object_id`).
         # @option options [Hash] :context Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @option options [Boolean] :consistent_read Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @option options [Boolean] :debug Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @return [Boolean] whether or not the given access check is authorized
@@ -314,7 +309,6 @@ module Warrant
                 return edge_authorize?(
                     op: op,
                     warrants: normalized_warrants,
-                    consistent_read: options[:consistent_read],
                     debug: options[:debug]
                 )
             end
@@ -322,7 +316,6 @@ module Warrant
             return authorize?(
                 op: op,
                 warrants: normalized_warrants,
-                consistent_read: options[:consistent_read],
                 debug: options[:debug]
             )
         end
@@ -332,7 +325,6 @@ module Warrant
         # @param user_id [String] Id of the user to check
         # @param permission_id [String] Id of the permission to check on the user
         # @param context [Hash] - Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @param consistentRead [Boolean] Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @param debug [Boolean] Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @return [Boolean] whether or not the user has the given permission
@@ -353,7 +345,6 @@ module Warrant
                     },
                     context: params[:context]
                 }],
-                consistentRead: params[:consistentRead],
                 debug: params[:debug]
             )
         end
@@ -365,7 +356,6 @@ module Warrant
         #   * object_id (String) - The id of the specific object.
         # @param feature_id [String] Id of the feature to check on the subject
         # @param context [Hash] - Object containing key-value pairs that specifies the context the warrant should be checked in. (optional)
-        # @param consistent_read [Boolean] Boolean flag indicating whether or not to enforce strict consistency for this access check. Defaults to false. (optional)
         # @param debug [Boolean] Boolean flag indicating whether or not to return debug information for this access check. Defaults to false. (optional)
         #
         # @return [Boolean] whether or not the user has the given permission
@@ -386,7 +376,6 @@ module Warrant
                     },
                     context: params[:context]
                 }],
-                consistent_read: params[:consistent_read],
                 debug: params[:debug]
             )
         end

--- a/lib/warrant/util.rb
+++ b/lib/warrant/util.rb
@@ -21,6 +21,11 @@ module Warrant
                 case params
                 when Hash
                     params.each_with_object({}) do |(k, v), new_opts|
+                        if k.to_s == "context"
+                            new_opts[k] = v
+                            next
+                        end
+
                         new_key = Util.camelcase(k.to_s)
 
                         case v

--- a/lib/warrant/util.rb
+++ b/lib/warrant/util.rb
@@ -21,6 +21,7 @@ module Warrant
                 case params
                 when Hash
                     params.each_with_object({}) do |(k, v), new_opts|
+                        # Leave context hash as-is to allow for any naming convention (snake_case vs camelCase)
                         if k.to_s == "context"
                             new_opts[k] = v
                             next

--- a/test/live_test.rb
+++ b/test/live_test.rb
@@ -477,4 +477,22 @@ class LiveTest < Minitest::Test
         Warrant::Tenant.delete(new_tenant.tenant_id)
         Warrant::Permission.delete(new_permission.permission_id)
     end
+
+    def test_warrants_with_policy
+        new_user = Warrant::User.create
+        new_permission = Warrant::Permission.create(permission_id: "permission-1", name: "Permission 1", description: "some permission")
+
+        # Assign permission to user with context
+        Warrant::Warrant.create(new_permission, "member", new_user, "geo == 'us' && isActivated == true")
+
+        assert_equal true, Warrant::Warrant.check(new_permission, "member", new_user, context: { "geo": "us", "isActivated": true })
+        assert_equal false, Warrant::Warrant.check(new_permission, "member", new_user, context: { "geo": "eu", "isActivated": false })
+
+        Warrant::Warrant.delete(new_permission, "member", new_user, "geo == 'us' && isActivated == true")
+
+        assert_equal false, Warrant::Warrant.check(new_permission, "member", new_user, { "geo": "us", "isActivated": true })
+
+        Warrant::User.delete(new_user.user_id)
+        Warrant::Permission.delete(new_permission.permission_id)
+    end
 end


### PR DESCRIPTION
This PR adds support for creating and deleting warrants with a policy.

Creating warrants with a policy:
```
Warrant::Warrant.create(new_permission, "member", new_user, "geo == 'us' && isActivated == true")
```

Deleting warrants with a policy:
```
Warrant::Warrant.delete(new_permission, "member", new_user, "geo == 'us' && isActivated == true")
```